### PR TITLE
refactor(command-line): move scraper and messenger command-line funct…

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -10,11 +10,11 @@ To start the NetWatch server without a user interface::
 The server can be closed by entering Ctrl-C in the console.
 To start NetWatch with a user interface::
 
-    $ python -m netwatch --enable_gui True
+    $ python -m netwatch --enable_gui
 
 When the user interface is enabled, the server will automatically close with
 the GUI window.
-You can also use the --enable_scheduler argument to enable or disable NetWatch's
+You can also use the `--disable_scheduler` argument to disable NetWatch's
 alert scheduler.
 
 To start NetWatch from within a project::

--- a/netwatch/__main__.py
+++ b/netwatch/__main__.py
@@ -1,19 +1,76 @@
 from argparse import ArgumentParser
 from netwatch.main import run
+import netwatch.messenger
+import netwatch.scraper
+import netwatch.gui
 
 if __name__ == "__main__":
     parser = ArgumentParser()
     parser.add_argument(
         "--enable_gui",
-        type=bool,
-        default=False,
+        action="store_true",
         help="Starts and closes the server with the GUI",
     )
     parser.add_argument(
-        "--enable_scheduler",
-        type=bool,
-        default=True,
-        help="Starts and closes the server with the scheduler",
+        "--disable_scheduler",
+        action="store_true",
+        help="Disables the NetWatch Alert scheduler",
     )
+
+    parser.add_argument("--messenger", action="store_true",
+                        help="Flag for using the messenger module")
+    parser.add_argument(
+        "--email_client", help="SMTP or SendGrid", default="smtp")
+    parser.add_argument("--username", help="The sender's email address")
+    parser.add_argument(
+        "--password", help="The sender's email password", default=None)
+    parser.add_argument("--api_key", help="SendGrid API Key", default=None)
+    parser.add_argument("--body", help="Email body")
+    parser.add_argument("--subject", help="Email subject")
+    parser.add_argument("--recipient", help="Recipient email address")
+    parser.add_argument(
+        "--smtp_addr", help="SMTP email server address", default="smtp.googlemail.com"
+    )
+
+    parser.add_argument("--scraper", action="store_true",
+                        help="Flag for using the scraper module")
+    parser.add_argument("--link", help="Link to page to be scraped")
+    parser.add_argument(
+        "--selector", help="CSS selector for portion of page to be scraped")
+
+    parser.add_argument("--gui", action="store_true",
+                        help="Starts the NetWatch GUI on its own")
+
     args = parser.parse_args()
-    run(enable_gui=args.enable_gui, enable_scheduler=args.enable_scheduler)
+
+    if args.messenger:
+        if args.email_client == "smtp":
+            netwatch.messenger.send_smtp_email(
+                username=args.username,
+                password=args.password,
+                subject=args.subject,
+                body=args.body,
+                recipient=args.recipient,
+                smtp_addr=args.smtp_addr,
+            )
+        else:
+            netwatch.messenger.send_sendgrid_email(
+                username=args.username,
+                api_key=args.api_key,
+                subject=args.subject,
+                body=args.body,
+                recipient=args.recipient,
+                body_type="text/plain"
+            )
+    elif args.scraper:
+        data = netwatch.scraper.fetch_site_html(netwatch.scraper.SiteData(
+            id="",
+            link=args.link,
+            selector=args.selector
+        ))[0]
+
+        print("{} - {} - {}".format(args.link, args.selector, data.html))
+    elif args.gui:
+        netwatch.gui.GUI()
+    else:
+        run(enable_gui=args.enable_gui, disable_scheduler=args.disable_scheduler)

--- a/netwatch/main.py
+++ b/netwatch/main.py
@@ -6,14 +6,14 @@ from netwatch.server import Server
 from netwatch.store import store
 
 
-def run(enable_gui=False, enable_scheduler=True):
+def run(enable_gui=False, disable_scheduler=False):
     if len(store.get_config()) == 0:
         config = config_window()
         store.update_config(new_setting=True, **config)
 
     scheduler = Scheduler()
     server = Server()
-    if enable_scheduler:
+    if not disable_scheduler:
         scheduler.start()
     server.start()
     if enable_gui:
@@ -26,25 +26,7 @@ def run(enable_gui=False, enable_scheduler=True):
         except KeyboardInterrupt:
             pass
     print("Shutting down...")
-    if enable_scheduler:
+    if not disable_scheduler:
         scheduler.stop()
     server.stop()
     store.save()
-
-
-if __name__ == "__main__":
-    parser = ArgumentParser()
-    parser.add_argument(
-        "--enable_gui",
-        type=bool,
-        default=False,
-        help="Starts and closes the server with the GUI",
-    )
-    parser.add_argument(
-        "--enable_scheduler",
-        type=bool,
-        default=True,
-        help="Starts and closes the server with the scheduler",
-    )
-    args = parser.parse_args()
-    run(enable_gui=args.enable_gui, enable_scheduler=args.enable_scheduler)

--- a/netwatch/messenger.py
+++ b/netwatch/messenger.py
@@ -4,14 +4,11 @@ This module allows for sending email and (in the near future)
 text notifications with a variety of service providers.
 
 Example:
-    This module can be used from the command line and as an import.
-    Command line example::
+    Command-line usage::
 
-        $ python messenger.py --username e@mail.com --password 1234 \
-            --body "ody ody ody" --subject Subject --recipient u@mail.com \
-            --smtp_addr smtp.googlemail.com
+        $ python -m netwatch --messenger --username e@mail.com --password 1234 --body "ody ody ody" --subject Testing --recipient u@mail.com
 
-    Import example::
+    Import usage::
 
         >>> import messenger
         >>> messenger.send_smtp_email(
@@ -27,8 +24,6 @@ Todo:
     * Add SMS gateway support
     * Add Twilio SMS support
 """
-
-from argparse import ArgumentParser
 
 import keyring
 from envelopes import Envelope
@@ -86,40 +81,3 @@ def send_sendgrid_email(username, api_key, subject, body, recipient, body_type):
     content = Content(body_type, body)
     mail = Mail(from_email, to_email, subject, content)
     sg.client.mail.send.post(request_body=mail.get())
-
-
-if __name__ == "__main__":
-    parser = ArgumentParser()
-    parser.add_argument(
-        "--email_client", help="SMTP or SendGrid", default="smtp")
-    parser.add_argument("--username", help="The sender's email address")
-    parser.add_argument(
-        "--password", help="The sender's email password", default=None)
-    parser.add_argument("--api_key", help="SendGrid API Key", default=None)
-    parser.add_argument("--body", help="Email body")
-    parser.add_argument("--subject", help="Email subject")
-    parser.add_argument("--recipient", help="Recipient email address")
-    parser.add_argument(
-        "--smtp_addr", help="SMTP email server address", default="smtp.googlemail.com"
-    )
-
-    args = parser.parse_args()
-
-    if args.email_client == "smtp":
-        send_smtp_email(
-            username=args.username,
-            password=args.password,
-            subject=args.subject,
-            body=args.body,
-            recipient=args.recipient,
-            smtp_addr=args.smtp_addr,
-        )
-    else:
-        send_sendgrid_email(
-            username=args.username,
-            api_key=args.api_key,
-            subject=args.subject,
-            body=args.body,
-            recipient=args.recipient,
-            body_type="text/plain"
-        )

--- a/netwatch/scraper.py
+++ b/netwatch/scraper.py
@@ -1,12 +1,11 @@
 """Module for retrieving HTML from static and dynamic websites.
 
 Example:
-    This module can be used as a standalone module or as an import.
-    Standalone example::
+    Command-line usage::
 
-        $ python scraper.py --link https://google.com --selector div 
+        $ python -m netwatch --scraper --link https://google.com --selector "div > p"
 
-    Import example::
+    Import usage::
 
         >>> import scraper
         >>> scraper.fetch_site_html(scraper.SiteData(
@@ -19,9 +18,6 @@ Example:
 Todo:
     * Add support for other browsers
 """
-
-from argparse import ArgumentParser
-from datetime import datetime
 
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
@@ -101,18 +97,3 @@ def fetch_site_html(
             driver = initialize_driver(chromedriver_path, driver_options)
     driver.close()
     return site_data
-
-
-if __name__ == "__main__":
-    parser = ArgumentParser()
-    parser.add_argument("--link")
-    parser.add_argument("--selector")
-    args = parser.parse_args()
-
-    data = fetch_site_html(SiteData(
-        id="",
-        link=args.link,
-        selector=args.selector
-    ))[0]
-
-    print("{} - {} - {}".format(args.link, args.selector, data.html))


### PR DESCRIPTION
…ionality

Moves messenger and scraper command line functionality so it can be accessed through the package `-m` flag. Just add `--messenger` or `--scraper` to access them. Also changes the `--enable_gui True/False` and `--enable_scheduler True/False` arguments to be `--enable_gui` and `--disable_scheduler`.

Closes #6 